### PR TITLE
Fix GitHub code connector

### DIFF
--- a/backend/onyx/connectors/github_code/connector.py
+++ b/backend/onyx/connectors/github_code/connector.py
@@ -13,7 +13,11 @@ from onyx.connectors.interfaces import (
     GenerateDocumentsOutput,
     SecondsSinceUnixEpoch,
 )
-from onyx.connectors.models import Document, Section, ConnectorMissingCredentialError
+from onyx.connectors.models import (
+    Document,
+    TextSection,
+    ConnectorMissingCredentialError,
+)
 from onyx.configs.constants import DocumentSource
 from onyx.utils.logger import setup_logger
 
@@ -365,13 +369,13 @@ class GitHubCodeConnector(LoadConnector, PollConnector):
         
         try:
             # Create Section with proper structure - pass link and text as keyword arguments
-            section = Section(link=doc_url, text=content)
+            section = TextSection(link=doc_url, text=content)
             
             # Create the document
             doc = Document(
                 id=doc_id,
                 sections=[section],  # Pass the Section object, not a dict
-                source=DocumentSource.GITHUB,
+                source=DocumentSource.GITHUB_CODE,
                 semantic_identifier=f"{repo_name}/{file_path}",
                 doc_updated_at=datetime.now(timezone.utc),
                 primary_owners=[],


### PR DESCRIPTION
## Summary
- fix document creation in GitHub code connector

## Testing
- `python -m mypy onyx/connectors/github_code/connector.py` *(fails: Error importing plugin `sqlalchemy.ext.mypy.plugin`)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_683fb34b2634832bb90b2cf3f28c56b8